### PR TITLE
Make Arcane Barrier obtainable

### DIFF
--- a/src/main/java/dev/cammiescorner/arcanus/core/util/SpellBooks.java
+++ b/src/main/java/dev/cammiescorner/arcanus/core/util/SpellBooks.java
@@ -40,7 +40,7 @@ public class SpellBooks {
 	}
 
 	public static ItemStack getRandomSpellBook(ItemStack stack) {
-		return SpellBooks.getSpellBook(stack, Arcanus.SPELL.get(RAND.nextInt(Arcanus.SPELL.getEntries().size() - 1)));
+		return SpellBooks.getSpellBook(stack, Arcanus.SPELL.get(RAND.nextInt(Arcanus.SPELL.getEntries().size())));
 	}
 
 	public static ItemStack getRandomSpellBook() {


### PR DESCRIPTION
Fixes an off-by-one error that prevented Arcane Barrier from generating in the wild.

Fixes #28